### PR TITLE
fix: remove manifestFile to fit gradle 3.x

### DIFF
--- a/betauploader/src/main/groovy/com.tencent.bugly.plugin/BetaPlugin.groovy
+++ b/betauploader/src/main/groovy/com.tencent.bugly.plugin/BetaPlugin.groovy
@@ -92,7 +92,7 @@ public class BetaPlugin implements Plugin<Project> {
      * @return
      */
     public UploadInfo generateUploadInfo(Object variant) {
-        def manifestFile = variant.outputs.processManifest.manifestOutputFile[0]
+//        def manifestFile = variant.outputs.processManifest.manifestOutputFile[0]
 //        println("-> Manifest: " + manifestFile)
 //        println("VersionCode: " + variant.getVersionCode() + " VersionName: " + variant.getVersionName())
 

--- a/bintray.gradle
+++ b/bintray.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.jfrog.bintray'
 apply plugin: 'maven-publish'
 
 group = "com.tencent.bugly.plugin"
-version = "1.0.0"
+version = "1.0.1"
 
 def baseUrl = 'https://github.com/BuglyDevTeam'
 def siteUrl = baseUrl


### PR DESCRIPTION
移除[BetaPlugin.groovy#L95](https://github.com/BuglyDevTeam/BuglyBetaUploader/blob/master/betauploader/src/main/groovy/com.tencent.bugly.plugin/BetaPlugin.groovy#L95)，适配 Gradle 3.X